### PR TITLE
Fix teleport sample

### DIFF
--- a/example/circuits.js
+++ b/example/circuits.js
@@ -129,15 +129,14 @@ const teleport = {
     qubits: [
         {
             id: 0,
-            numChildren: 2,
+            numChildren: 1,
         },
         {
             id: 1,
-            numChildren: 2,
+            numChildren: 1,
         },
         {
             id: 2,
-            numChildren: 1,
         },
     ],
     operations: [


### PR DESCRIPTION
There's an extra classical register in each quantum register in the teleport sample. This small PR just fixes that.