### PR TITLE
Fixing collidng css class with bootstrap

### DIFF
--- a/__tests__/__snapshots__/gateFormatter.test.ts.snap
+++ b/__tests__/__snapshots__/gateFormatter.test.ts.snap
@@ -345,7 +345,7 @@ exports[`Testing _controlledGate SWAP gate 3`] = `
 exports[`Testing _createGate Expanded gate 1`] = `
 "<g class='gate' data-a='1' data-b='2' data-expanded='true'>
 <line />
-<g class='gate-control collapse' transform='translate(2.5, Infinity)'>
+<g class='gate-control gate-collapse' transform='translate(2.5, Infinity)'>
 <circle cx=\\"0\\" cy=\\"0\\" r=\\"10\\" />
 <path d=\\"M-7,0 H7\\" />
 </g>
@@ -468,7 +468,7 @@ exports[`Testing _formatGate swap gate 1`] = `
 
 exports[`Testing _gateControls Expanded gate 1`] = `
 Array [
-  "<g class='gate-control collapse' transform='translate(2.5, Infinity)'>
+  "<g class='gate-control gate-collapse' transform='translate(2.5, Infinity)'>
 <circle cx=\\"0\\" cy=\\"0\\" r=\\"10\\" />
 <path d=\\"M-7,0 H7\\" />
 </g>",
@@ -477,7 +477,7 @@ Array [
 
 exports[`Testing _gateControls Expanded with children gate 1`] = `
 Array [
-  "<g class='gate-control collapse' transform='translate(2.5, Infinity)'>
+  "<g class='gate-control gate-collapse' transform='translate(2.5, Infinity)'>
 <circle cx=\\"0\\" cy=\\"0\\" r=\\"10\\" />
 <path d=\\"M-7,0 H7\\" />
 </g>",
@@ -486,7 +486,7 @@ Array [
 
 exports[`Testing _gateControls Non-expanded with children gate 1`] = `
 Array [
-  "<g class='gate-control expand' transform='translate(2.5, Infinity)'>
+  "<g class='gate-control gate-expand' transform='translate(2.5, Infinity)'>
 <circle cx=\\"0\\" cy=\\"0\\" r=\\"10\\" />
 <path d=\\"M0,-7 V7 M-7,0 H7\\" />
 </g>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/quantum-viz.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "quantum-viz.js is a configurable tool for visualizing quantum circuits.",
   "main": "dist/qviz.min.js",
   "scripts": {

--- a/src/formatters/gateFormatter.ts
+++ b/src/formatters/gateFormatter.ts
@@ -42,14 +42,14 @@ const _gateControls = (metadata: Metadata, nestedDepth: number): string[] => {
     if (expanded) {
         ctrls.push(
             group(['<circle cx="0" cy="0" r="10" />', '<path d="M-7,0 H7" />'], {
-                class: 'gate-control collapse',
+                class: 'gate-control gate-collapse',
                 transform: `translate(${x1 + 2}, ${y1 + 2})`,
             }),
         );
     } else if (atts['zoom-in'] == 'true') {
         ctrls.push(
             group(['<circle cx="0" cy="0" r="10" />', '<path d="M0,-7 V7 M-7,0 H7" />'], {
-                class: 'gate-control expand',
+                class: 'gate-control gate-expand',
                 transform: `translate(${x1 + 2}, ${y1 + 2})`,
             }),
         );

--- a/src/sqore.ts
+++ b/src/sqore.ts
@@ -272,9 +272,9 @@ export class Sqore {
             ctrl.addEventListener('click', (ev: Event) => {
                 const gateId: string | null | undefined = ctrl.parentElement?.getAttribute('data-id');
                 if (typeof gateId == 'string') {
-                    if (ctrl.classList.contains('collapse')) {
+                    if (ctrl.classList.contains('gate-collapse')) {
                         this.collapseOperation(circuit.operations, gateId);
-                    } else if (ctrl.classList.contains('expand')) {
+                    } else if (ctrl.classList.contains('gate-expand')) {
                         this.expandOperation(circuit.operations, gateId);
                     }
                     this.renderCircuit(container, circuit);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -183,38 +183,38 @@ export const style = (customStyle: StyleConfig = {}): string => {
         fill: ${styleConfig.classicalZeroText};
     }
 
-    .qviz .collapse,
-    .qviz .expand {
+    .qviz .gate-collapse,
+    .qviz .gate-expand {
         opacity: 0;
         transition: opacity 1s;
     }
 
-    .qviz:hover .collapse,
-    .qviz:hover .expand {
+    .qviz:hover .gate-collapse,
+    .qviz:hover .gate-expand {
         visibility: visible;
         opacity: 0.2;
         transition: visibility 1s;
         transition: opacity 1s;
     }
 
-    .expand, .collapse {
+    .gate-expand, .gate-collapse {
         cursor: pointer;
     }
 
-    .collapse circle,
-    .expand circle {
+    .gate-collapse circle,
+    .gate-expand circle {
         fill: white;
         stroke-width: 2px;
         stroke: black;
     }
-    .collapse path,
-    .expand path {
+    .gate-collapse path,
+    .gate-expand path {
         stroke-width: 4px;
         stroke: black;
     }
 
-    .gate:hover > .collapse,
-    .gate:hover > .expand {
+    .gate:hover > .gate-collapse,
+    .gate:hover > .gate-expand {
         visibility: visible;
         opacity: 1;
         transition: opacity 1s;


### PR DESCRIPTION
# Description

As I'm integrating with iq#, the only problem I found is that the `.collapse` css class is collading with a class with the same name from bootstrap, so the collapse button never shows up.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Live on iQ#.

