### PR TITLE
Expand top-level gates by default

### DIFF
--- a/example/circuits.js
+++ b/example/circuits.js
@@ -6,7 +6,7 @@
 // Basic example: entanglement with measurement
 //export
 const entangle = {
-    qubits: [{ id: 0 }, { id: 1 }],
+    qubits: [{ id: 0 }, { id: 1, numChildren: 1 }],
     operations: [
         {
             gate: 'H',
@@ -17,6 +17,12 @@ const entangle = {
             isControlled: true,
             controls: [{ qId: 0 }],
             targets: [{ qId: 1 }],
+        },
+        {
+            gate: 'Measure',
+            isMeasurement: true,
+            controls: [{ qId: 1 }],
+            targets: [{ type: 1, qId: 1, cId: 0 }],
         },
     ],
 };

--- a/example/circuits.js
+++ b/example/circuits.js
@@ -3,7 +3,26 @@
 
 /* eslint-disable  @typescript-eslint/no-unused-vars */
 
+// Basic example: entanglement with measurement
+//export
+const entangle = {
+    qubits: [{ id: 0 }, { id: 1 }],
+    operations: [
+        {
+            gate: 'H',
+            targets: [{ qId: 0 }],
+        },
+        {
+            gate: 'X',
+            isControlled: true,
+            controls: [{ qId: 0 }],
+            targets: [{ qId: 1 }],
+        },
+    ],
+};
+
 // Sample circuit
+//export
 const sample = {
     qubits: [{ id: 0, numChildren: 1 }, { id: 1 }, { id: 2 }, { id: 3 }],
     operations: [
@@ -128,6 +147,7 @@ const sample = {
 };
 
 // Teleportation algorithm
+//export
 const teleport = {
     qubits: [
         {
@@ -394,6 +414,7 @@ const teleport = {
 };
 
 // Grover's algorithm
+//export
 const grover = {
     qubits: [
         {

--- a/example/index.html
+++ b/example/index.html
@@ -13,6 +13,8 @@
         <i>Running from source</i> instructions from the README.md
     </div>
     
+    <h1>Some sample circuits rendered by qviz:</h1>
+    <div id="entangle"></div>
     <div id="sample"></div>
     <div id="teleport"></div>
     <div id="grover"></div>

--- a/example/script.js
+++ b/example/script.js
@@ -5,6 +5,11 @@ if (typeof qviz != 'undefined') {
     document.getElementById('msg').style.display = 'none';
 
     /* These examples shows how to draw circuits into containers. */
+    const entangleDiv = document.getElementById('entangle');
+    if (entangleDiv != null) {
+        qviz.draw(entangle, entangleDiv, qviz.STYLES['Default']);
+    }
+
     const sampleDiv = document.getElementById('sample');
     if (sampleDiv != null) {
         qviz.draw(sample, sampleDiv, qviz.STYLES['Default']);

--- a/src/sqore.ts
+++ b/src/sqore.ts
@@ -70,7 +70,7 @@ export class Sqore {
 
         // If only one top-level operation, expand automatically:
         if (circuit.operations.length == 1 && circuit.operations[0].dataAttributes != null) {
-            const id : string =  circuit.operations[0].dataAttributes['id'];
+            const id: string = circuit.operations[0].dataAttributes['id'];
             this.expandOperation(circuit.operations, id);
         }
 

--- a/src/sqore.ts
+++ b/src/sqore.ts
@@ -69,7 +69,11 @@ export class Sqore {
         circuit.operations = this.selectOpsAtDepth(circuit.operations, renderDepth);
 
         // If only one top-level operation, expand automatically:
-        if (circuit.operations.length == 1 && circuit.operations[0].dataAttributes != null && circuit.operations[0].dataAttributes.hasOwnProperty('id')) {
+        if (
+            circuit.operations.length == 1 &&
+            circuit.operations[0].dataAttributes != null &&
+            circuit.operations[0].dataAttributes.hasOwnProperty('id')
+        ) {
             const id: string = circuit.operations[0].dataAttributes['id'];
             this.expandOperation(circuit.operations, id);
         }

--- a/src/sqore.ts
+++ b/src/sqore.ts
@@ -69,7 +69,7 @@ export class Sqore {
         circuit.operations = this.selectOpsAtDepth(circuit.operations, renderDepth);
 
         // If only one top-level operation, expand automatically:
-        if (circuit.operations.length == 1 && circuit.operations[0].dataAttributes != null) {
+        if (circuit.operations.length == 1 && circuit.operations[0].dataAttributes != null && circuit.operations[0].dataAttributes.hasOwnProperty('id')) {
             const id: string = circuit.operations[0].dataAttributes['id'];
             this.expandOperation(circuit.operations, id);
         }

--- a/src/sqore.ts
+++ b/src/sqore.ts
@@ -67,6 +67,13 @@ export class Sqore {
 
         // Render operations at starting at given depth
         circuit.operations = this.selectOpsAtDepth(circuit.operations, renderDepth);
+
+        // If only one top-level operation, expand automatically:
+        if (circuit.operations.length == 1 && circuit.operations[0].dataAttributes != null) {
+            const id : string =  circuit.operations[0].dataAttributes['id'];
+            this.expandOperation(circuit.operations, id);
+        }
+
         this.renderCircuit(container, circuit);
     }
 


### PR DESCRIPTION
# Description

When a circuit has only one top level gate (a common scenario for q# generated circuits), it is better to have the gate automatically expanded.

Fixes #31 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
