### PR TITLE
Add qiskit python parser

### DIFF
--- a/example/qiskit_parser/qc_parser.py
+++ b/example/qiskit_parser/qc_parser.py
@@ -1,0 +1,103 @@
+import json
+import qiskit
+
+# Pass in a quantumCircuit created using IBM's Qiskit
+def qc_parser(quantumCircuit):
+    qbitCount = quantumCircuit.num_qubits + quantumCircuit.num_ancillas # Number of qubits and ancilla bits in Qiskit
+    clbitCount = quantumCircuit.num_clbits # Number of Classical Bits
+    print(quantumCircuit.parameters)
+    outputCircuit = {"qubits":[], "operations":[]}
+
+    qubits = []
+    operations = []
+    ignore = ["barrier"] #Terms in Qiskit that don't translate to QuantumViz
+
+    # Add an id number for each qbit
+    for i in range(qbitCount):
+        qubits.append({"id": i})
+
+    #print(quantumCircut.h(0).label)
+
+    # Loop through each of the elements of the circuit.
+    # Each element of quantumCircuit.data basically corresponds to the function call used to create that element and appears sequentially
+    # https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit.data
+    for qc in quantumCircuit.data:
+
+        isMeasurement = 'false'
+        isConditional = 'false'
+        out = {}
+
+        # Each different type of gate has a different structure that needs to be parsed (measurement, control, etc).
+        # print(qc)
+
+        instruction = qc[0].name
+        print(qc[0])
+        # print("Gate " + qc[0].name)
+        out['gate'] = instruction.upper()
+
+        # Make sure it is something supported by QuantumViz
+        if instruction not in ignore:
+
+            out['controls'] = []
+            out['targets'] = []
+            controlOut = {}
+            
+            # Last element of the array in the first element of qc is the target
+            qbitTarget = qc[1][-1].index
+
+            # Add isMeasurement key for when it is measurement gate.
+            if instruction == "measure":
+                out['isMeasurement'] = 'true'
+                out['controls'].append({'qId': qbitTarget})
+            
+
+            # Is a control qubit if the array has more than one element.
+            # Example:
+            # 
+            # For a Qiskit command to create a controlled X Gate in ancilla 0 tied to quantum registers 0, 1, 2:
+            # qc.cx(qr[0:3], anc[0])
+            # You may get an element such as the following in qc[1][0]:
+            # [Qubit(QuantumRegister(3, 'q'), 0), Qubit(QuantumRegister(1, 'ancilla'), 0)]
+            # The index is the qbit that is controlled by the target. The target in this case being ancilla bit 0 and the controlled one being the 0th element
+            # of the 3 Quantum Registers available.
+
+            if (len(qc[1]) > 1): 
+
+                out['isControlled'] = 'true'
+                print(qc[1])
+                for i in (range(len(qc[1]) - 1)):
+                    qbitControlled = qc[1][i].index
+                    print(qc[1][i])
+                    print(qbitControlled)
+                    if (qc[1][i].register.name == "ancilla"):
+                        qbitControlled = qbitControlled + quantumCircuit.num_qubits - 1
+                        
+                    controlOut["type"] = 0
+                    controlOut["qId"] = qbitControlled
+
+                    out['controls'].append(controlOut.copy())
+                    controlOut.clear()
+
+
+            if (qc[1][-1].register.name == "ancilla"):
+                qbitTarget = qbitTarget + quantumCircuit.num_qubits - 1
+
+            out['targets'].append({'qId': qbitTarget})
+
+            # print(out)
+            operations.append(out.copy()) # Add instruction dict to output array
+            # Clear temporary dict for next loop
+            out.clear()
+
+    outputCircuit["qubits"] = qubits
+    outputCircuit["operations"] = operations
+    print("output:")
+    print(outputCircuit)
+    jsonOutput  = json.dumps(outputCircuit, indent=2)
+    outputFile = open('quantum.json', 'w') # Outputs to "quantum.json" file
+    outputFile.write(jsonOutput)
+    outputFile.close()
+
+    # Post Process:
+    # I have been pasting the output from quantum.json to: https://csvjson.com/json_beautifier
+    # I select no quotes: on keys and quotes: single

--- a/example/qiskit_parser/qskit_parser_test.ipynb
+++ b/example/qiskit_parser/qskit_parser_test.ipynb
@@ -1,0 +1,339 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.9.5 64-bit ('qiskit': conda)"
+  },
+  "interpreter": {
+   "hash": "2c5b1a7a6495a30544972baa96a8850cbe45fafa3dce99d03214c29b73e345ae"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This is a testbed for playing with the the qc_parser function. Create a Qiskit circuit and pass it into qc_parser."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "source": [
+    "import json\r\n",
+    "import qiskit\r\n",
+    "\r\n",
+    "# Pass in a quantumCircuit created using IBM's Qiskit\r\n",
+    "def qc_parser(quantumCircuit):\r\n",
+    "    qbitCount = quantumCircuit.num_qubits + quantumCircuit.num_ancillas # Number of qubits and ancilla bits in Qiskit\r\n",
+    "    clbitCount = quantumCircuit.num_clbits # Number of Classical Bits\r\n",
+    "    print(quantumCircuit.parameters)\r\n",
+    "    outputCircuit = {\"qubits\":[], \"operations\":[]}\r\n",
+    "\r\n",
+    "    qubits = []\r\n",
+    "    operations = []\r\n",
+    "    ignore = [\"barrier\"] #Terms in Qiskit that don't translate to QuantumViz\r\n",
+    "\r\n",
+    "    # Add an id number for each qbit\r\n",
+    "    for i in range(qbitCount):\r\n",
+    "        qubits.append({\"id\": i})\r\n",
+    "\r\n",
+    "    #print(quantumCircut.h(0).label)\r\n",
+    "\r\n",
+    "    # Loop through each of the elements of the circuit.\r\n",
+    "    # Each element of quantumCircuit.data basically corresponds to the function call used to create that element and appears sequentially\r\n",
+    "    # https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit.data\r\n",
+    "    for qc in quantumCircuit.data:\r\n",
+    "\r\n",
+    "        isMeasurement = 'false'\r\n",
+    "        isConditional = 'false'\r\n",
+    "        out = {}\r\n",
+    "\r\n",
+    "        # Each different type of gate has a different structure that needs to be parsed (measurement, control, etc).\r\n",
+    "        # print(qc)\r\n",
+    "\r\n",
+    "        instruction = qc[0].name\r\n",
+    "        print(qc[0])\r\n",
+    "        # print(\"Gate \" + qc[0].name)\r\n",
+    "        out['gate'] = instruction.upper()\r\n",
+    "\r\n",
+    "        # Make sure it is something supported by QuantumViz\r\n",
+    "        if instruction not in ignore:\r\n",
+    "\r\n",
+    "            out['controls'] = []\r\n",
+    "            out['targets'] = []\r\n",
+    "            controlOut = {}\r\n",
+    "            \r\n",
+    "            # Last element of the array in the first element of qc is the target\r\n",
+    "            qbitTarget = qc[1][-1].index\r\n",
+    "\r\n",
+    "            # Add isMeasurement key for when it is measurement gate.\r\n",
+    "            if instruction == \"measure\":\r\n",
+    "                out['isMeasurement'] = 'true'\r\n",
+    "                out['controls'].append({'qId': qbitTarget})\r\n",
+    "            \r\n",
+    "\r\n",
+    "            # Is a control qubit if the array has more than one element.\r\n",
+    "            # Example:\r\n",
+    "            # \r\n",
+    "            # For a Qiskit command to create a controlled X Gate in ancilla 0 tied to quantum registers 0, 1, 2:\r\n",
+    "            # qc.cx(qr[0:3], anc[0])\r\n",
+    "            # You may get an element such as the following in qc[1][0]:\r\n",
+    "            # [Qubit(QuantumRegister(3, 'q'), 0), Qubit(QuantumRegister(1, 'ancilla'), 0)]\r\n",
+    "            # The index is the qbit that is controlled by the target. The target in this case being ancilla bit 0 and the controlled one being the 0th element\r\n",
+    "            # of the 3 Quantum Registers available.\r\n",
+    "\r\n",
+    "            if (len(qc[1]) > 1): \r\n",
+    "\r\n",
+    "                out['isControlled'] = 'true'\r\n",
+    "                print(qc[1])\r\n",
+    "                for i in (range(len(qc[1]) - 1)):\r\n",
+    "                    qbitControlled = qc[1][i].index\r\n",
+    "                    print(qc[1][i])\r\n",
+    "                    print(qbitControlled)\r\n",
+    "                    if (qc[1][i].register.name == \"ancilla\"):\r\n",
+    "                        qbitControlled = qbitControlled + quantumCircuit.num_qubits - 1\r\n",
+    "                        \r\n",
+    "                    controlOut[\"type\"] = 0\r\n",
+    "                    controlOut[\"qId\"] = qbitControlled\r\n",
+    "\r\n",
+    "                    out['controls'].append(controlOut.copy())\r\n",
+    "                    controlOut.clear()\r\n",
+    "\r\n",
+    "\r\n",
+    "            if (qc[1][-1].register.name == \"ancilla\"):\r\n",
+    "                qbitTarget = qbitTarget + quantumCircuit.num_qubits - 1\r\n",
+    "\r\n",
+    "            out['targets'].append({'qId': qbitTarget})\r\n",
+    "\r\n",
+    "            # print(out)\r\n",
+    "            operations.append(out.copy()) # Add instruction dict to output array\r\n",
+    "            # Clear temporary dict for next loop\r\n",
+    "            out.clear()\r\n",
+    "\r\n",
+    "    outputCircuit[\"qubits\"] = qubits\r\n",
+    "    outputCircuit[\"operations\"] = operations\r\n",
+    "    print(\"output:\")\r\n",
+    "    print(outputCircuit)\r\n",
+    "    jsonOutput  = json.dumps(outputCircuit, indent=2)\r\n",
+    "    outputFile = open('quantum.json', 'w') # Outputs to \"quantum.json\" file\r\n",
+    "    outputFile.write(jsonOutput)\r\n",
+    "    outputFile.close()\r\n",
+    "\r\n",
+    "    # Post Process:\r\n",
+    "    # I have been pasting the output from quantum.json to: https://csvjson.com/json_beautifier\r\n",
+    "    # I select no quotes: on keys and quotes: single"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "source": [
+    "from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit\r\n",
+    "\r\n",
+    "qr = QuantumRegister(3, 'q')\r\n",
+    "anc = QuantumRegister(1, 'ancilla')\r\n",
+    "cr = ClassicalRegister(3, 'c')\r\n",
+    "qc = QuantumCircuit(qr, anc, cr)\r\n",
+    "\r\n",
+    "\r\n",
+    "qc.h(qr[0:3])\r\n",
+    "qc.x(anc[0])\r\n",
+    "qc.h(anc[0])\r\n",
+    "qc.cx(qr[0:3], anc[0])\r\n",
+    "qc.h(qr[0:3])\r\n",
+    "qc.barrier(qr)\r\n",
+    "qc.measure(qr, cr)\r\n",
+    "\r\n",
+    "qc_parser(qc)\r\n",
+    "\r\n",
+    "qc.draw()"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "ParameterView([])\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C21E353DF0>\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C21E353DF0>\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C21E353DF0>\n",
+      "<qiskit.circuit.library.standard_gates.x.XGate object at 0x000001C21E45DFA0>\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C231BB6FD0>\n",
+      "<qiskit.circuit.library.standard_gates.x.CXGate object at 0x000001C231BB6040>\n",
+      "[Qubit(QuantumRegister(3, 'q'), 0), Qubit(QuantumRegister(1, 'ancilla'), 0)]\n",
+      "Qubit(QuantumRegister(3, 'q'), 0)\n",
+      "0\n",
+      "<qiskit.circuit.library.standard_gates.x.CXGate object at 0x000001C231BB6040>\n",
+      "[Qubit(QuantumRegister(3, 'q'), 1), Qubit(QuantumRegister(1, 'ancilla'), 0)]\n",
+      "Qubit(QuantumRegister(3, 'q'), 1)\n",
+      "1\n",
+      "<qiskit.circuit.library.standard_gates.x.CXGate object at 0x000001C231BB6040>\n",
+      "[Qubit(QuantumRegister(3, 'q'), 2), Qubit(QuantumRegister(1, 'ancilla'), 0)]\n",
+      "Qubit(QuantumRegister(3, 'q'), 2)\n",
+      "2\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C21E353AF0>\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C21E353AF0>\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C21E353AF0>\n",
+      "<qiskit.circuit.barrier.Barrier object at 0x000001C231B9C5B0>\n",
+      "<qiskit.circuit.measure.Measure object at 0x000001C231BB6FA0>\n",
+      "<qiskit.circuit.measure.Measure object at 0x000001C231BB6FA0>\n",
+      "<qiskit.circuit.measure.Measure object at 0x000001C231BB6FA0>\n",
+      "output:\n",
+      "{'qubits': [{'id': 0}, {'id': 1}, {'id': 2}, {'id': 3}], 'operations': [{'gate': 'H', 'controls': [], 'targets': [{'qId': 0}]}, {'gate': 'H', 'controls': [], 'targets': [{'qId': 1}]}, {'gate': 'H', 'controls': [], 'targets': [{'qId': 2}]}, {'gate': 'X', 'controls': [], 'targets': [{'qId': 3}]}, {'gate': 'H', 'controls': [], 'targets': [{'qId': 3}]}, {'gate': 'CX', 'controls': [{'type': 0, 'qId': 0}], 'targets': [{'qId': 3}], 'isControlled': 'true'}, {'gate': 'CX', 'controls': [{'type': 0, 'qId': 1}], 'targets': [{'qId': 3}], 'isControlled': 'true'}, {'gate': 'CX', 'controls': [{'type': 0, 'qId': 2}], 'targets': [{'qId': 3}], 'isControlled': 'true'}, {'gate': 'H', 'controls': [], 'targets': [{'qId': 0}]}, {'gate': 'H', 'controls': [], 'targets': [{'qId': 1}]}, {'gate': 'H', 'controls': [], 'targets': [{'qId': 2}]}, {'gate': 'MEASURE', 'controls': [{'qId': 0}], 'targets': [{'qId': 0}], 'isMeasurement': 'true'}, {'gate': 'MEASURE', 'controls': [{'qId': 1}], 'targets': [{'qId': 1}], 'isMeasurement': 'true'}, {'gate': 'MEASURE', 'controls': [{'qId': 2}], 'targets': [{'qId': 2}], 'isMeasurement': 'true'}]}\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "<ipython-input-65-d48a4f538cb7>:46: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  qbitTarget = qc[1][-1].index\n",
+      "<ipython-input-65-d48a4f538cb7>:82: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  if (qc[1][-1].register.name == \"ancilla\"):\n",
+      "<ipython-input-65-d48a4f538cb7>:69: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  qbitControlled = qc[1][i].index\n",
+      "<ipython-input-65-d48a4f538cb7>:72: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  if (qc[1][i].register.name == \"ancilla\"):\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "           ┌───┐          ┌───┐           ░ ┌─┐      \n",
+       "      q_0: ┤ H ├───────■──┤ H ├───────────░─┤M├──────\n",
+       "           ├───┤       │  └───┘┌───┐      ░ └╥┘┌─┐   \n",
+       "      q_1: ┤ H ├───────┼────■──┤ H ├──────░──╫─┤M├───\n",
+       "           ├───┤       │    │  └───┘┌───┐ ░  ║ └╥┘┌─┐\n",
+       "      q_2: ┤ H ├───────┼────┼────■──┤ H ├─░──╫──╫─┤M├\n",
+       "           ├───┤┌───┐┌─┴─┐┌─┴─┐┌─┴─┐└───┘ ░  ║  ║ └╥┘\n",
+       "ancilla_0: ┤ X ├┤ H ├┤ X ├┤ X ├┤ X ├─────────╫──╫──╫─\n",
+       "           └───┘└───┘└───┘└───┘└───┘         ║  ║  ║ \n",
+       "      c: 3/══════════════════════════════════╩══╩══╩═\n",
+       "                                             0  1  2 "
+      ],
+      "text/html": [
+       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">           ┌───┐          ┌───┐           ░ ┌─┐      \n",
+       "      q_0: ┤ H ├───────■──┤ H ├───────────░─┤M├──────\n",
+       "           ├───┤       │  └───┘┌───┐      ░ └╥┘┌─┐   \n",
+       "      q_1: ┤ H ├───────┼────■──┤ H ├──────░──╫─┤M├───\n",
+       "           ├───┤       │    │  └───┘┌───┐ ░  ║ └╥┘┌─┐\n",
+       "      q_2: ┤ H ├───────┼────┼────■──┤ H ├─░──╫──╫─┤M├\n",
+       "           ├───┤┌───┐┌─┴─┐┌─┴─┐┌─┴─┐└───┘ ░  ║  ║ └╥┘\n",
+       "ancilla_0: ┤ X ├┤ H ├┤ X ├┤ X ├┤ X ├─────────╫──╫──╫─\n",
+       "           └───┘└───┘└───┘└───┘└───┘         ║  ║  ║ \n",
+       "      c: 3/══════════════════════════════════╩══╩══╩═\n",
+       "                                             0  1  2 </pre>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 68
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "source": [
+    "from qiskit import QuantumCircuit\r\n",
+    "# Create a circuit with a register of three qubits\r\n",
+    "circ = QuantumCircuit(3)\r\n",
+    "# H gate on qubit 0, putting this qubit in a superposition of |0> + |1>.\r\n",
+    "circ.h(0)\r\n",
+    "# A CX (CNOT) gate on control qubit 0 and target qubit 1 generating a Bell state.\r\n",
+    "circ.cx(0, 1)\r\n",
+    "# CX (CNOT) gate on control qubit 0 and target qubit 2 resulting in a GHZ state.\r\n",
+    "circ.cx(0, 2)\r\n",
+    "qc_parser(circ)\r\n",
+    "# Draw the circuit\r\n",
+    "circ.draw()\r\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "ParameterView([])\n",
+      "<qiskit.circuit.library.standard_gates.h.HGate object at 0x000001C231B68760>\n",
+      "<qiskit.circuit.library.standard_gates.x.CXGate object at 0x000001C23087E880>\n",
+      "[Qubit(QuantumRegister(3, 'q'), 0), Qubit(QuantumRegister(3, 'q'), 1)]\n",
+      "Qubit(QuantumRegister(3, 'q'), 0)\n",
+      "0\n",
+      "<qiskit.circuit.library.standard_gates.x.CXGate object at 0x000001C230E7CFA0>\n",
+      "[Qubit(QuantumRegister(3, 'q'), 0), Qubit(QuantumRegister(3, 'q'), 2)]\n",
+      "Qubit(QuantumRegister(3, 'q'), 0)\n",
+      "0\n",
+      "output:\n",
+      "{'qubits': [{'id': 0}, {'id': 1}, {'id': 2}], 'operations': [{'gate': 'H', 'controls': [], 'targets': [{'qId': 0}]}, {'gate': 'CX', 'controls': [{'type': 0, 'qId': 0}], 'targets': [{'qId': 1}], 'isControlled': 'true'}, {'gate': 'CX', 'controls': [{'type': 0, 'qId': 0}], 'targets': [{'qId': 2}], 'isControlled': 'true'}]}\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "<ipython-input-65-d48a4f538cb7>:46: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  qbitTarget = qc[1][-1].index\n",
+      "<ipython-input-65-d48a4f538cb7>:82: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  if (qc[1][-1].register.name == \"ancilla\"):\n",
+      "<ipython-input-65-d48a4f538cb7>:69: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  qbitControlled = qc[1][i].index\n",
+      "<ipython-input-65-d48a4f538cb7>:72: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
+      "  if (qc[1][i].register.name == \"ancilla\"):\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "     ┌───┐          \n",
+       "q_0: ┤ H ├──■────■──\n",
+       "     └───┘┌─┴─┐  │  \n",
+       "q_1: ─────┤ X ├──┼──\n",
+       "          └───┘┌─┴─┐\n",
+       "q_2: ──────────┤ X ├\n",
+       "               └───┘"
+      ],
+      "text/html": [
+       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">     ┌───┐          \n",
+       "q_0: ┤ H ├──■────■──\n",
+       "     └───┘┌─┴─┐  │  \n",
+       "q_1: ─────┤ X ├──┼──\n",
+       "          └───┘┌─┴─┐\n",
+       "q_2: ──────────┤ X ├\n",
+       "               └───┘</pre>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 67
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
Initial commit of a parser for IBM Qiskit quantum circuits to output to json file compatible with Quantum-Viz.

# Description

Adding a basic parser for Qiskit quantum circuits. Currently supports basic Qiskit circuits that contain basic gates, control gates, and measurement gates.

# Testing

There is a python juypter notebook called qskit_parser_test.ipynb that acts as a testbed to continue expanding on the parser and add additional support for Qiskit objects.
