### PR TITLE
Fixed prettier version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^26.0.4",
+    "@types/prettier": "2.6.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "canvas": "^2.6.1",
@@ -40,7 +41,7 @@
     "eslint-plugin-jest": "^23.20.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.6.3",
-    "prettier": "^2.0.5",
+    "prettier": "2.6.0",
     "terser-webpack-plugin": "^4.1.0",
     "ts-jest": "^26.1.2",
     "ts-loader": "^8.0.2",


### PR DESCRIPTION
Thanks @aaronthangnguyen for reporting #53. Indeed, this was caused by https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60314

Fixes it by fixing the version of prettier to 2.6.0, otherwise we'll need to upgrade `tsc` which is not a change we're ready to take.