### PR TITLE
Fix Jupyter display

### DIFF
--- a/quantum-viz/quantum_viz/widget.py
+++ b/quantum-viz/quantum_viz/widget.py
@@ -134,7 +134,7 @@ class Viewer:
     def _ipython_display_(self) -> None:
         """Display the widget with IPython."""
         viewer = HTML(self.html_str())
-        display((viewer,))
+        display(viewer)
 
     def browser_display(self) -> None:
         """Display the widget in the browser."""


### PR DESCRIPTION
# Description

For an unknown reason, we were passing a list to `display` instead of a single object with the HTML view. This used to work, but it was broken for recent Jupyter and Jupyter Lab versions.

Fixes #68 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Automated and manual tests on Jupyter

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
