### PR TITLE
Fix link in Python package README.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -49,7 +49,7 @@
 # is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
-*.md   diff=astextplain
+#*.md    diff=astextplain
 #*.doc   diff=astextplain
 #*.DOC   diff=astextplain
 #*.docx  diff=astextplain

--- a/quantum-viz/README.md
+++ b/quantum-viz/README.md
@@ -83,4 +83,4 @@ display(qc)
 
 ## Contributing
 
-Check out our [contributing guidelines](./CONTRIBUTING.md) to find out how you can contribute to quantum-viz.
+Check out our [contributing guidelines](https://github.com/microsoft/quantum-viz.js/blob/main/quantum-viz/CONTRIBUTING.md) to find out how you can contribute to quantum-viz.


### PR DESCRIPTION
The link to the contributing guidelines was broken on the pypi package, as it was a relative link to the CONTRIBUTING.md file. This updates the README to point to the full URL.